### PR TITLE
check if value can be converted

### DIFF
--- a/src/dash/contrib/plugins/rss_feed/templatetags/rss_feed_tags.py
+++ b/src/dash/contrib/plugins/rss_feed/templatetags/rss_feed_tags.py
@@ -1,4 +1,5 @@
 import datetime
+from time import struct_time
 
 from django import template
 


### PR DESCRIPTION
If an RSS feed entry doesn't have a date field the value is an empty string which caused this template filter to fail. 
In my solution a do a type check, but may be you find it more pythonic to use a try except :-).
