### PR TITLE
Uploading images failed

### DIFF
--- a/src/dash/contrib/plugins/image/helpers.py
+++ b/src/dash/contrib/plugins/image/helpers.py
@@ -19,6 +19,9 @@ from dash.contrib.plugins.image.settings import (
 logger = logging.getLogger(__file__)
 
 IMAGES_UPLOAD_DIR_ABSOLUTE_PATH = os.path.join(settings.MEDIA_ROOT, IMAGES_UPLOAD_DIR)
+if not os.path.exists(IMAGES_UPLOAD_DIR_ABSOLUTE_PATH):
+    os.makedirs(IMAGES_UPLOAD_DIR_ABSOLUTE_PATH)
+
 
 def ensure_unique_filename(destination):
     """


### PR DESCRIPTION
Uploading images failed, cause the upload dir didn't exist. Added an check (when this python file is loaded) if the image upload dir exists if not it is automatically created.
