### PR TITLE
Ability to use different layouts per workspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 # Command to install dependencies
 install:
-  - pip install -r example/requirements.txt
+  - pip install -r examples/requirements.txt
   - python setup.py install
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' && $DJANGO15 == true ]]; then pip uninstall Django -y; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' && $DJANGO15 == true ]]; then pip install Django==1.5.5; fi
@@ -30,19 +30,19 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $DJANGO16 == true ]]; then pip uninstall Django -y; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '2.7' && $DJANGO16 == true ]]; then pip install Django==1.6; fi
   #- if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip uninstall django-localeurl -y; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install -r example/requirements3.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then pip install -r examples/requirements3.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' && $DJANGO15 == true ]]; then pip uninstall Django -y; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' && $DJANGO15 == true ]]; then pip install Django==1.5.5; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' && $DJANGO16 == true ]]; then pip uninstall Django -y; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' && $DJANGO16 == true ]]; then pip install Django==1.6; fi
-  - mkdir example/db
-  - mkdir example/logs
-  - mkdir example/media
-  - mkdir example/media/static
-  - python example/example/manage.py syncdb --noinput 
+  - mkdir examples/db
+  - mkdir examples/logs
+  - mkdir examples/media
+  - mkdir examples/media/static
+  - python examples/example/manage.py syncdb --noinput 
 # --noinput --traceback -v 3
 # Command to run tests
 script: 
-  - python example/example/manage.py test dash
+  - python examples/example/manage.py test dash
 # --traceback -v 3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' && $DJANGO15 == true ]]; then pip install Django==1.5.5; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' && $DJANGO16 == true ]]; then pip uninstall Django -y; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.3' && $DJANGO16 == true ]]; then pip install Django==1.6; fi
-  - mkdir examples/db
   - mkdir examples/logs
   - mkdir examples/media
   - mkdir examples/media/static

--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,10 @@ Key concepts
 ===============================================
 - Each layout (theme) consist of placeholders. Each plugin widget has its' own
   specific HTML/JavaScript/CSS.
-- There might be multiple themes implemented and installed, but only one can 
-  be active for a certain user. Default layout is chosen system wide, but each
-  user (if has an appropriate permission) can choose his preferred layout.
+- There might be multiple themes implemented and installed. Default layout is 
+  chosen system wide, but each user (if has an appropriate permission) can
+  choose his preferred layout over all workspaces or even different layouts 
+  per workspace.
 - Placeholder is a space, in which the plugin widgets are placed.
 - Placeholders are rectangles consisting of cells. Each placeholder has its' 
   own custom number of rows and columns.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,9 +26,10 @@ Key concepts
 ===============================================
 - Each layout (theme) consist of placeholders. Each plugin widget has its' own
   specific HTML/JavaScript/CSS.
-- There might be multiple themes implemented and installed, but only one can 
-  be active for a certain user. Default layout is chosen system wide, but each
-  user (if has an appropriate permission) can choose his preferred layout.
+- There might be multiple themes implemented and installed. Default layout is
+  chosen system wide, but each user (if has an appropriate permission) can 
+  choose his preferred layout over all workspaces or even different layouts 
+  per workspace.
 - Placeholder is a space, in which the plugin widgets are placed.
 - Placeholders are rectangles consisting of cells. Each placeholder has its' 
   own custom number of rows and columns.

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -5,8 +5,8 @@ django-admin-tools>=0.5.1
 #django-autoslug==1.7.1
 django-debug-toolbar==0.11.0
 django-registration-redux>=1.1
-ipdb==0.8
-ipython>=2.3.0
+#ipdb==0.8
+#ipython>=2.3.0
 lorem-ipsum-generator==0.3
 #MySQL-python==1.2.4
 ordereddict==1.1

--- a/src/dash/base.py
+++ b/src/dash/base.py
@@ -974,8 +974,7 @@ class BaseDashboardPlugin(object):
         """
         return self.form
 
-    def get_initialised_create_form(self, data=None, files=None, \
-                                    different_layouts=False):
+    def get_initialised_create_form(self, data=None, files=None):
         """
         Used ``dash.views.add_dashboard_entry`` view to gets initialised form
         for object to be created.
@@ -988,16 +987,13 @@ class BaseDashboardPlugin(object):
                     return plugin_form(
                         data=data,
                         files=files,
-                        different_layouts=different_layouts
                     )
             except Exception as e:
                 if DEBUG:
                     logger.debug(e)
                 raise Http404(e)
 
-    def get_initialised_create_form_or_404(self, data=None, \
-                                           files=None, \
-                                           different_layouts=False):
+    def get_initialised_create_form_or_404(self, data=None, files=None):
         """
         Same as ``get_initialised_create_form`` but raises
         ``django.http.Http404`` on errors.
@@ -1008,7 +1004,6 @@ class BaseDashboardPlugin(object):
                 return self.get_initialised_create_form(
                     data=data,
                     files=files,
-                    different_layouts=different_layouts
                 )
             except Exception as e:
                 if DEBUG:
@@ -1018,8 +1013,7 @@ class BaseDashboardPlugin(object):
     def get_initialised_edit_form(self, data=None, files=None, \
                                   auto_id='id_%s', prefix=None, initial=None, \
                                   error_class=ErrorList, label_suffix=':', \
-                                  empty_permitted=False, instance=None, \
-                                  different_layouts=False):
+                                  empty_permitted=False, instance=None):
         """
         Used in ``dash.views.edit_dashboard_entry`` view.
         """
@@ -1034,7 +1028,6 @@ class BaseDashboardPlugin(object):
                 'error_class': error_class,
                 'label_suffix': label_suffix,
                 'empty_permitted': empty_permitted,
-                'different_layouts': different_layouts,
             }
             if issubclass(plugin_form, ModelForm):
                 kwargs.update({'instance': instance})
@@ -1044,8 +1037,7 @@ class BaseDashboardPlugin(object):
                                          auto_id='id_%s', prefix=None, \
                                          error_class=ErrorList, \
                                          label_suffix=':', \
-                                         empty_permitted=False, \
-                                         different_layouts=False):
+                                         empty_permitted=False):
         """
         Same as ``get_initialised_edit_form`` but raises ``django.http.Http404``
         on errors.
@@ -1063,7 +1055,6 @@ class BaseDashboardPlugin(object):
                     label_suffix = label_suffix,
                     empty_permitted = empty_permitted,
                     instance = self.get_instance(),
-                    different_layouts = different_layouts
                     )
             except Exception as e:
                 if DEBUG:

--- a/src/dash/base.py
+++ b/src/dash/base.py
@@ -984,10 +984,7 @@ class BaseDashboardPlugin(object):
             try:
                 plugin_form = self.get_form()
                 if plugin_form:
-                    return plugin_form(
-                        data=data,
-                        files=files,
-                    )
+                    return plugin_form(data=data, files=files)
             except Exception as e:
                 if DEBUG:
                     logger.debug(e)
@@ -1001,10 +998,7 @@ class BaseDashboardPlugin(object):
         plugin_form = self.get_form()
         if plugin_form:
             try:
-                return self.get_initialised_create_form(
-                    data=data,
-                    files=files,
-                )
+                return self.get_initialised_create_form(data=data, files=files)
             except Exception as e:
                 if DEBUG:
                     logger.debug(e)
@@ -1027,7 +1021,7 @@ class BaseDashboardPlugin(object):
                 'initial': initial,
                 'error_class': error_class,
                 'label_suffix': label_suffix,
-                'empty_permitted': empty_permitted,
+                'empty_permitted': empty_permitted
             }
             if issubclass(plugin_form, ModelForm):
                 kwargs.update({'instance': instance})
@@ -1054,7 +1048,7 @@ class BaseDashboardPlugin(object):
                     error_class = error_class,
                     label_suffix = label_suffix,
                     empty_permitted = empty_permitted,
-                    instance = self.get_instance(),
+                    instance = self.get_instance()
                     )
             except Exception as e:
                 if DEBUG:

--- a/src/dash/base.py
+++ b/src/dash/base.py
@@ -974,7 +974,8 @@ class BaseDashboardPlugin(object):
         """
         return self.form
 
-    def get_initialised_create_form(self, data=None, files=None):
+    def get_initialised_create_form(self, data=None, files=None, \
+                                    different_layouts=False):
         """
         Used ``dash.views.add_dashboard_entry`` view to gets initialised form
         for object to be created.
@@ -984,13 +985,19 @@ class BaseDashboardPlugin(object):
             try:
                 plugin_form = self.get_form()
                 if plugin_form:
-                    return plugin_form(data=data, files=files)
+                    return plugin_form(
+                        data=data,
+                        files=files,
+                        different_layouts=different_layouts
+                    )
             except Exception as e:
                 if DEBUG:
                     logger.debug(e)
                 raise Http404(e)
 
-    def get_initialised_create_form_or_404(self, data=None, files=None):
+    def get_initialised_create_form_or_404(self, data=None, \
+                                           files=None, \
+                                           different_layouts=False):
         """
         Same as ``get_initialised_create_form`` but raises
         ``django.http.Http404`` on errors.
@@ -998,7 +1005,11 @@ class BaseDashboardPlugin(object):
         plugin_form = self.get_form()
         if plugin_form:
             try:
-                return self.get_initialised_create_form(data=data, files=files)
+                return self.get_initialised_create_form(
+                    data=data,
+                    files=files,
+                    different_layouts=different_layouts
+                )
             except Exception as e:
                 if DEBUG:
                     logger.debug(e)
@@ -1007,7 +1018,8 @@ class BaseDashboardPlugin(object):
     def get_initialised_edit_form(self, data=None, files=None, \
                                   auto_id='id_%s', prefix=None, initial=None, \
                                   error_class=ErrorList, label_suffix=':', \
-                                  empty_permitted=False, instance=None):
+                                  empty_permitted=False, instance=None, \
+                                  different_layouts=False):
         """
         Used in ``dash.views.edit_dashboard_entry`` view.
         """
@@ -1021,7 +1033,8 @@ class BaseDashboardPlugin(object):
                 'initial': initial,
                 'error_class': error_class,
                 'label_suffix': label_suffix,
-                'empty_permitted': empty_permitted
+                'empty_permitted': empty_permitted,
+                'different_layouts': different_layouts,
             }
             if issubclass(plugin_form, ModelForm):
                 kwargs.update({'instance': instance})
@@ -1031,7 +1044,8 @@ class BaseDashboardPlugin(object):
                                          auto_id='id_%s', prefix=None, \
                                          error_class=ErrorList, \
                                          label_suffix=':', \
-                                         empty_permitted=False):
+                                         empty_permitted=False, \
+                                         different_layouts=False):
         """
         Same as ``get_initialised_edit_form`` but raises ``django.http.Http404``
         on errors.
@@ -1048,7 +1062,8 @@ class BaseDashboardPlugin(object):
                     error_class = error_class,
                     label_suffix = label_suffix,
                     empty_permitted = empty_permitted,
-                    instance = self.get_instance()
+                    instance = self.get_instance(),
+                    different_layouts = different_layouts
                     )
             except Exception as e:
                 if DEBUG:

--- a/src/dash/forms.py
+++ b/src/dash/forms.py
@@ -7,6 +7,7 @@ __all__ = ('DashboardWorkspaceForm',)
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
+from dash.base import get_registered_layouts
 from dash.models import DashboardWorkspace, DashboardSettings, DashboardPlugin
 from dash.constants import ACTION_CHOICES
 
@@ -14,14 +15,25 @@ class DashboardWorkspaceForm(forms.ModelForm):
     """
     Dashboard workspace form.
     """
+    layout_uid = forms.TypedChoiceField(
+        label=_('Layout'),
+        choices=get_registered_layouts(),
+        empty_value=None,
+    )
+
     class Meta:
         model = DashboardWorkspace
-        fields = ('user', 'name', 'is_public', 'is_clonable')
+        fields = ('layout_uid', 'user', 'name', 'is_public', 'is_clonable')
 
     def __init__(self, *args, **kwargs):
+        different_layouts = kwargs.get('different_layouts', False)
+        if 'different_layouts' in kwargs:
+            del kwargs['different_layouts']
         super(DashboardWorkspaceForm, self).__init__(*args, **kwargs)
         self.fields['user'].widget = forms.widgets.HiddenInput()
-        #self.fields['layout_uid'].widget = forms.widgets.HiddenInput()
+        print self.fields['layout_uid']
+        if not different_layouts:
+            self.fields['layout_uid'].widget = forms.widgets.HiddenInput()
 
 
 class DashboardSettingsForm(forms.ModelForm):

--- a/src/dash/forms.py
+++ b/src/dash/forms.py
@@ -26,12 +26,9 @@ class DashboardWorkspaceForm(forms.ModelForm):
         fields = ('layout_uid', 'user', 'name', 'is_public', 'is_clonable')
 
     def __init__(self, *args, **kwargs):
-        different_layouts = kwargs.get('different_layouts', False)
-        if 'different_layouts' in kwargs:
-            del kwargs['different_layouts']
+        different_layouts = kwargs.pop('different_layouts', False)
         super(DashboardWorkspaceForm, self).__init__(*args, **kwargs)
         self.fields['user'].widget = forms.widgets.HiddenInput()
-        print self.fields['layout_uid']
         if not different_layouts:
             self.fields['layout_uid'].widget = forms.widgets.HiddenInput()
 

--- a/src/dash/migrations/0003_auto__add_field_dashboardsettings_allow_different_layouts.py
+++ b/src/dash/migrations/0003_auto__add_field_dashboardsettings_allow_different_layouts.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Adding field 'DashboardSettings.allow_different_layouts'
+        db.add_column(u'dash_dashboardsettings', 'allow_different_layouts',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+
+        # Deleting field 'DashboardSettings.allow_different_layouts'
+        db.delete_column(u'dash_dashboardsettings', 'allow_different_layouts')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'dash.dashboardentry': {
+            'Meta': {'object_name': 'DashboardEntry'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'layout_uid': ('django.db.models.fields.CharField', [], {'max_length': '25'}),
+            'placeholder_uid': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'plugin_data': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'plugin_uid': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'position': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'workspace': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['dash.DashboardWorkspace']", 'null': 'True', 'blank': 'True'})
+        },
+        u'dash.dashboardplugin': {
+            'Meta': {'object_name': 'DashboardPlugin'},
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['auth.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'plugin_uid': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'users': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        u'dash.dashboardsettings': {
+            'Meta': {'object_name': 'DashboardSettings'},
+            'allow_different_layouts': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'layout_uid': ('django.db.models.fields.CharField', [], {'max_length': '25'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True'})
+        },
+        u'dash.dashboardworkspace': {
+            'Meta': {'unique_together': "(('user', 'slug'), ('user', 'name'))", 'object_name': 'DashboardWorkspace'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_clonable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'layout_uid': ('django.db.models.fields.CharField', [], {'max_length': '25'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'position': ('dash.fields.OrderField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('autoslug.fields.AutoSlugField', [], {'unique': 'True', 'max_length': '50', 'populate_from': "'name'", 'unique_with': '()'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['dash']

--- a/src/dash/models.py
+++ b/src/dash/models.py
@@ -35,6 +35,9 @@ class DashboardSettings(models.Model):
     user = models.ForeignKey(User, verbose_name=_("User"), unique=True)
     layout_uid = models.CharField(_("Layout"), max_length=25, choices=get_registered_layouts())
     title = models.CharField(_("Title"), max_length=255)
+    allow_different_layouts = models.BooleanField(_("Allow different layouts per workspace?"), default=False, \
+                                                  help_text=_("Allows you to use different layouts for each "
+                                                              "workspace."))
     is_public = models.BooleanField(_("Is public?"), default=False, \
                                     help_text=_("Makes your dashboard to be visible to the public. Visibility "
                                                 "of workspaces could be adjust separately for each workspace, "

--- a/src/dash/utils.py
+++ b/src/dash/utils.py
@@ -259,7 +259,7 @@ def sync_plugins():
 
     DashboardPlugin._default_manager.bulk_create(buf)
 
-def get_workspaces(user, layout_uid=None, workspace=None, public=False):
+def get_workspaces(user, layout_uid=None, workspace=None, public=False, different_layouts=False):
     """
     Gets previous, current, next and and a queryset of all workspaces.
 
@@ -268,7 +268,9 @@ def get_workspaces(user, layout_uid=None, workspace=None, public=False):
     :return dict:
     """
     # We need to show workspaces
-    q_kwargs = {'user': user, 'layout_uid': layout_uid}
+    q_kwargs = {'user': user}
+    if not different_layouts:
+        q_kwargs.update({'layout_uid': layout_uid})
     if public:
         q_kwargs.update({'is_public': public})
 

--- a/src/dash/views.py
+++ b/src/dash/views.py
@@ -294,7 +294,6 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
             form = plugin.get_initialised_create_form_or_404(
                 data=request.POST,
                 files=request.FILES,
-                different_layouts=dashboard_settings.allow_different_layouts
                 )
             if form.is_valid():
                 # Saving the plugin form data.
@@ -328,9 +327,7 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
 
         # If POST but data invalid, show the form with errors.
         else:
-            form = plugin.get_initialised_create_form_or_404(
-                different_layouts=dashboard_settings.allow_different_layouts
-            )
+            form = plugin.get_initialised_create_form_or_404()
 
         context.update(
             {'form': form, 'plugin_uid': plugin_uid, 'plugin': plugin}
@@ -403,7 +400,6 @@ def edit_dashboard_entry(request, entry_id, \
             form = plugin.get_initialised_edit_form_or_404(
                 data=request.POST,
                 files=request.FILES,
-                different_layouts=dashboard_settings.allow_different_layouts
                 )
             if form.is_valid():
                 # Saving the plugin form data.
@@ -427,9 +423,7 @@ def edit_dashboard_entry(request, entry_id, \
                     return redirect('dash.edit_dashboard')
 
         else:
-            form = plugin.get_initialised_edit_form_or_404(
-                different_layouts=dashboard_settings.allow_different_layouts
-            )
+            form = plugin.get_initialised_edit_form_or_404()
 
         context.update({'form': form, 'plugin': plugin})
 

--- a/src/dash/views.py
+++ b/src/dash/views.py
@@ -292,8 +292,7 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
         # to the dashboard edit.
         if 'POST' == request.method:
             form = plugin.get_initialised_create_form_or_404(
-                data=request.POST,
-                files=request.FILES,
+                data=request.POST, files=request.FILES
                 )
             if form.is_valid():
                 # Saving the plugin form data.

--- a/src/dash/views.py
+++ b/src/dash/views.py
@@ -147,7 +147,7 @@ def edit_dashboard(request, workspace=None):
 
     workspaces = get_workspaces(
         request.user,
-        dasboard_settings.layout_uid,
+        dashboard_settings.layout_uid,
         workspace,
         different_layouts=dashboard_settings.allow_different_layouts,
     )

--- a/src/dash/views.py
+++ b/src/dash/views.py
@@ -369,8 +369,8 @@ def edit_dashboard_entry(request, entry_id, \
     except ObjectDoesNotExist as e:
         raise Http404(e)
 
-    if obj.workspace.layout_uid:
-        layout_uid = obj.workspace.layout_uid
+    if obj.layout_uid:
+        layout_uid = obj.layout_uid
     else:
         layout_uid = dashboard_settings.layout_uid
 

--- a/src/dash/views.py
+++ b/src/dash/views.py
@@ -66,10 +66,30 @@ def dashboard(request, workspace=None):
 
     # Getting dashboard settings for the user. Then get users' layout.
     dashboard_settings = get_or_create_dashboard_settings(request.user)
+
+    workspaces = get_workspaces(
+        request.user,
+        dashboard_settings.layout_uid,
+        workspace,
+        different_layouts=dashboard_settings.allow_different_layouts
+    )
+
     layout = get_layout(
-        layout_uid = dashboard_settings.layout_uid,
-        as_instance = True
-        )
+        layout_uid=workspaces['current_workspace'].layout_uid if workspaces['current_workspace'] else dashboard_settings.layout_uid,
+        as_instance=True
+    )
+
+    # If workspace with slug given is not found in the list of workspaces
+    # redirect to the default dashboard.
+    if workspaces['current_workspace_not_found']:
+        msg = _('The workspace with slug "{0}" does '
+                'not belong to layout "{1}".').format(workspace, layout.name)
+        if dashboard_settings.allow_different_layouts:
+            msg = _('The workspace with slug "{0}" does not exist').format(
+                workspace
+            )
+        messages.info(request, msg)
+        return redirect('dash.edit_dashboard')
 
     # Getting the (frozen) queryset.
     dashboard_entries = DashboardEntry._default_manager \
@@ -94,18 +114,6 @@ def dashboard(request, workspace=None):
         'layout': layout,
         'dashboard_settings': dashboard_settings
     }
-
-    workspaces = get_workspaces(request.user, layout.uid, workspace)
-
-    # If workspace with slug given is not found in the list of workspaces
-    # redirect to the default dashboard.
-    if workspaces['current_workspace_not_found']:
-        messages.info(
-            request,
-            _('The workspace with slug "{0}" does '
-              'not belong to layout "{1}".').format(workspace, layout.name)
-            )
-        return redirect('dash.edit_dashboard')
 
     context.update(workspaces)
 
@@ -136,9 +144,28 @@ def edit_dashboard(request, workspace=None):
 
     # Getting dashboard settings for the user. Then get users' layout.
     dashboard_settings = get_or_create_dashboard_settings(request.user)
+
+    workspaces = get_workspaces(
+        request.user,
+        dasboard_settings.layout_uid,
+        workspace,
+        different_layouts=dashboard_settings.allow_different_layouts,
+    )
+
     layout = get_layout(
-        layout_uid=dashboard_settings.layout_uid, as_instance=True
-        )
+        layout_uid=workspaces['current_workspace'].layout_uid if workspaces['current_workspace'] else dashboard_settings.layout_uid,
+        as_instance=True
+    )
+
+    # If workspace with slug given is not found in the list of workspaces
+    # redirect to the default dashboard.
+    if workspaces['current_workspace_not_found']:
+        messages.info(
+            request,
+            _('The workspace with slug "{0}" does '
+              'not belong to layout "{1}".').format(workspace, layout.name)
+            )
+        return redirect('dash.edit_dashboard')
 
     # Getting the (frozen) queryset.
     dashboard_entries = DashboardEntry._default_manager \
@@ -163,18 +190,6 @@ def edit_dashboard(request, workspace=None):
         'edit_mode': True,
         'dashboard_settings': dashboard_settings
     }
-
-    workspaces = get_workspaces(request.user, layout.uid, workspace)
-
-    # If workspace with slug given is not found in the list of workspaces
-    # redirect to the default dashboard.
-    if workspaces['current_workspace_not_found']:
-        messages.info(
-            request,
-            _('The workspace with slug "{0}" does '
-              'not belong to layout "{1}".').format(workspace, layout.name)
-            )
-        return redirect('dash.edit_dashboard')
 
     context.update(workspaces)
 
@@ -215,9 +230,34 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
     """
     # Getting dashboard settings for the user. Then get users' layout.
     dashboard_settings = get_or_create_dashboard_settings(request.user)
-    layout = get_layout(
-        layout_uid=dashboard_settings.layout_uid, as_instance=True
-        )
+
+    if workspace:
+        workspace_slug = slugify_workspace(workspace)
+        filters = {
+            'slug': workspace_slug,
+            'user': request.user,
+        }
+        if not dashboard_settings.allow_different_layouts:
+            filters.update({
+                'layout_uid': dashboard_settings.layout_uid,
+            })
+        try:
+            workspace = DashboardWorkspace._default_manager.get(**filters)
+        except ObjectDoesNotExist as e:
+            if dashboard_settings.allow_different_layouts:
+                message = _('The workspace with slug "{0}" was not foundi.').format(workspace_slug)
+            else:
+                message = __('The workspace with slug "{0}" does not belong to '
+                'layout "{1}".').format(workspace_slug, layout.name)
+            messages.info(request, message)
+            return redirect('dash.edit_dashboard')
+
+    if dashboard_settings.allow_different_layouts and workspace:
+        layout_uid = workspace.layout_uid
+    else:
+        layout_uid = dashboard_settings.layout_uid
+
+    layout = get_layout(layout_uid=layout_uid, as_instance=True)
 
     if not validate_placeholder_uid(layout, placeholder_uid):
         raise Http404(_("Invalid placeholder: {0}").format(placeholder))
@@ -242,6 +282,7 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
     obj.placeholder_uid = placeholder_uid
     obj.plugin_uid = plugin_uid
     obj.user = request.user
+    obj.workspace = workspace
 
     # If plugin has form, it is configurable which means we have to load the
     # plugin form and validate user input.
@@ -251,7 +292,9 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
         # to the dashboard edit.
         if 'POST' == request.method:
             form = plugin.get_initialised_create_form_or_404(
-                data=request.POST, files=request.FILES
+                data=request.POST,
+                files=request.FILES,
+                different_layouts=dashboard_settings.allow_different_layouts
                 )
             if form.is_valid():
                 # Saving the plugin form data.
@@ -259,24 +302,6 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
 
                 # Getting the plugin data.
                 obj.plugin_data = form.get_plugin_data(request=request)
-
-                # Handling the workspace.
-                obj.workspace = None
-                if workspace:
-                    workspace_slug = slugify_workspace(workspace)
-                    try:
-                        obj.workspace = DashboardWorkspace._default_manager.get(
-                            slug = workspace_slug,
-                            user = request.user,
-                            layout_uid = layout.uid
-                            )
-                    except ObjectDoesNotExist as e:
-                        messages.info(
-                            request,
-                            _('The workspace with slug "{0}" does not belong to '
-                              'layout "{1}".').format(workspace_slug, layout.name)
-                            )
-                        return redirect('dash.edit_dashboard')
 
                 # If position given, use it.
                 try:
@@ -303,7 +328,9 @@ def add_dashboard_entry(request, placeholder_uid, plugin_uid, workspace=None, \
 
         # If POST but data invalid, show the form with errors.
         else:
-            form = plugin.get_initialised_create_form_or_404()
+            form = plugin.get_initialised_create_form_or_404(
+                different_layouts=dashboard_settings.allow_different_layouts
+            )
 
         context.update(
             {'form': form, 'plugin_uid': plugin_uid, 'plugin': plugin}
@@ -337,9 +364,6 @@ def edit_dashboard_entry(request, entry_id, \
     """
     # Getting dashboard settings for the user. Then get users' layout.
     dashboard_settings = get_or_create_dashboard_settings(request.user)
-    layout = get_layout(
-        layout_uid=dashboard_settings.layout_uid, as_instance=True
-        )
 
     try:
         obj = DashboardEntry._default_manager \
@@ -347,6 +371,15 @@ def edit_dashboard_entry(request, entry_id, \
                             .get(pk=entry_id, user=request.user)
     except ObjectDoesNotExist as e:
         raise Http404(e)
+
+    if obj.workspace.layout_uid:
+        layout_uid = obj.workspace.layout_uid
+    else:
+        layout_uid = dashboard_settings.layout_uid
+
+    layout = get_layout(
+        layout_uid=layout_uid, as_instance=True
+        )
 
     plugin = obj.get_plugin(fetch_related_data=True)
     plugin.request = request
@@ -368,7 +401,9 @@ def edit_dashboard_entry(request, entry_id, \
         # to the dashboard edit.
         if 'POST' == request.method:
             form = plugin.get_initialised_edit_form_or_404(
-                data=request.POST, files=request.FILES
+                data=request.POST,
+                files=request.FILES,
+                different_layouts=dashboard_settings.allow_different_layouts
                 )
             if form.is_valid():
                 # Saving the plugin form data.
@@ -392,7 +427,9 @@ def edit_dashboard_entry(request, entry_id, \
                     return redirect('dash.edit_dashboard')
 
         else:
-            form = plugin.get_initialised_edit_form_or_404()
+            form = plugin.get_initialised_edit_form_or_404(
+                different_layouts=dashboard_settings.allow_different_layouts
+            )
 
         context.update({'form': form, 'plugin': plugin})
 
@@ -563,18 +600,29 @@ def create_dashboard_workspace(request, \
 
 
     if 'POST' == request.method:
-        form = DashboardWorkspaceForm(data=request.POST, files=request.FILES)
+        form = DashboardWorkspaceForm(
+            data=request.POST,
+            files=request.FILES,
+            different_layouts=dashboard_settings.allow_different_layouts
+        )
         if form.is_valid():
             obj = form.save(commit=False)
             obj.user = request.user
-            obj.layout_uid = layout.uid
+            if not dashboard_settings.allow_different_layouts:
+                obj.layout_uid = layout.uid
             obj.save()
             messages.info(request, _('The dashboard workspace "{0}" was '
                                      'created successfully.').format(obj.name))
             return redirect('dash.edit_dashboard', workspace=obj.slug)
 
     else:
-        form = DashboardWorkspaceForm(initial={'user': request.user})
+        form = DashboardWorkspaceForm(
+            initial={
+                'user': request.user,
+                'layout_uid': layout.uid,
+            },
+            different_layouts=dashboard_settings.allow_different_layouts
+        )
 
     if request.is_ajax():
         template_name = template_name_ajax
@@ -605,9 +653,6 @@ def edit_dashboard_workspace(request, workspace_id, \
     """
     # Getting dashboard settings for the user. Then get users' layout.
     dashboard_settings = get_or_create_dashboard_settings(request.user)
-    layout = get_layout(
-        layout_uid=dashboard_settings.layout_uid, as_instance=True
-        )
 
     # Check if user trying to edit the dashboard workspace actually owns it.
     try:
@@ -616,23 +661,32 @@ def edit_dashboard_workspace(request, workspace_id, \
     except ObjectDoesNotExist as e:
         raise Http404(e)
 
+    layout = get_layout(
+        layout_uid=obj.layout_uid, as_instance=True
+        )
+
     if 'POST' == request.method:
         form = DashboardWorkspaceForm(
             data = request.POST,
             files = request.FILES,
-            instance = obj
-            )
+            instance = obj,
+            different_layouts=dashboard_settings.allow_different_layouts
+        )
         if form.is_valid():
             form.save(commit=False)
             obj.user = request.user
-            obj.layout_uid = layout.uid
+            if not dashboard_settings.allow_different_layouts:
+                obj.layout_uid = layout.uid
             obj.save()
             messages.info(request, _('The dashboard workspace "{0}" was '
                                      'edited successfully.').format(obj.name))
             return redirect('dash.edit_dashboard', workspace=obj.slug)
 
     else:
-        form = DashboardWorkspaceForm(instance=obj)
+        form = DashboardWorkspaceForm(
+            instance=obj,
+            different_layouts=dashboard_settings.allow_different_layouts
+        )
 
     if request.is_ajax():
         template_name = template_name_ajax
@@ -664,9 +718,6 @@ def delete_dashboard_workspace(request, workspace_id, \
     """
     # Getting dashboard settings for the user. Then get users' layout.
     dashboard_settings = get_or_create_dashboard_settings(request.user)
-    layout = get_layout(
-        layout_uid=dashboard_settings.layout_uid, as_instance=True
-        )
 
     # Check if user trying to edit the dashboard workspace actually owns it and then delete the workspace.
     if 'POST' == request.method and 'delete' in request.POST is None and request.POST.get('next', None):
@@ -678,6 +729,10 @@ def delete_dashboard_workspace(request, workspace_id, \
 
     except ObjectDoesNotExist as e:
         raise Http404(e)
+
+    layout = get_layout(
+        layout_uid=workspace.layout_uid, as_instance=True
+        )
 
     if 'POST' == request.method:
         if 'delete' in request.POST:
@@ -732,15 +787,28 @@ def dashboard_workspaces(request, workspace=None, \
     """
     # Getting dashboard settings for the user. Then get users' layout.
     dashboard_settings = get_or_create_dashboard_settings(request.user)
-    layout = get_layout(
-        layout_uid=dashboard_settings.layout_uid, as_instance=True
-        )
 
-    context = {
+    context = get_workspaces(
+        request.user,
+        dashboard_settings.layout_uid,
+        workspace,
+        different_layouts=dashboard_settings.allow_different_layouts
+    )
+
+    if dashboard_settings.allow_different_layouts and context['current_workspace']:
+        layout_uid = context['current_workspace'].layout_uid
+    else:
+        layout_uid = dashboard_settings.layout_uid
+
+    layout = get_layout(
+        layout_uid=layout_uid,
+        as_instance=True
+    )
+
+    context.update({
         'layout': layout,
         'dashboard_settings': dashboard_settings
-    }
-    context.update(get_workspaces(request.user, layout.uid, workspace))
+    })
 
     if request.is_ajax():
         template_name = template_name_ajax
@@ -841,7 +909,8 @@ def clone_dashboard_workspace(request, workspace_id):
         layout_uid=dashboard_settings.layout_uid, as_instance=True
         )
 
-    if workspace.layout_uid == layout.uid:
+    if workspace.layout_uid == layout.uid or \
+            dashboard_settings.allow_different_layouts:
 
         messages.info(
             request,


### PR DESCRIPTION
I added the ability to use different layouts per workspace. This is done by selecting a checkbox in dashboard settings. Default behaviour is to use the same layout for every workspace (checkbox is not selected) and everything works as it did before.
If you allow to use different layouts, you can choose a layout while creating a workspace.
Main reason for doing this is to use different workspaces on different devices, such as phones, tablets and larger devices, as they have different needs and a workspace arranged for a large screen is nearly unusable on a phone.