### PR TITLE
Improve Django 1.11 compatibility. Import `flatatt` from the correct place.

### DIFF
--- a/src/dash/lib/tinymce/widgets.py
+++ b/src/dash/lib/tinymce/widgets.py
@@ -11,7 +11,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
 from django.core.urlresolvers import reverse
-from django.forms.widgets import flatatt
+from django.forms.utils import flatatt
 from django.utils.html import escape
 from django.utils.datastructures import SortedDict
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
This is compatible with Django 1.8, 1.9, 1.10 & 1.11.