### PR TITLE
SortedDict was deprecated in Django 1.7.

### DIFF
--- a/src/dash/lib/tinymce/widgets.py
+++ b/src/dash/lib/tinymce/widgets.py
@@ -7,13 +7,14 @@ http://code.djangoproject.com/wiki/CustomWidgetsTinyMCE
 """
 from __future__ import unicode_literals
 
+from collections import OrderedDict
+
 from django import forms
 from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
 from django.core.urlresolvers import reverse
 from django.forms.utils import flatatt
 from django.utils.html import escape
-from django.utils.datastructures import SortedDict
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, ugettext as _
 
@@ -186,7 +187,7 @@ def get_language_config(content_language=None):
     config = {}
     config['language'] = language
 
-    lang_names = SortedDict()
+    lang_names = OrderedDict()
     for lang, name in settings.LANGUAGES:
         if lang[:2] not in lang_names:
             lang_names[lang[:2]] = []


### PR DESCRIPTION
Using OrderedDict instead.